### PR TITLE
Add vsync to Vulkan

### DIFF
--- a/.ci/scripts/linux/upload.sh
+++ b/.ci/scripts/linux/upload.sh
@@ -5,21 +5,24 @@
 
 . .ci/scripts/common/pre-upload.sh
 
-APPIMAGE_NAME="yuzu-${GITDATE}-${GITREV}.AppImage"
-REV_NAME="yuzu-linux-${GITDATE}-${GITREV}"
+APPIMAGE_NAME="yuzu-${RELEASE_NAME}-${GITDATE}-${GITREV}.AppImage"
+BASE_NAME="yuzu-linux"
+REV_NAME="${BASE_NAME}-${GITDATE}-${GITREV}"
 ARCHIVE_NAME="${REV_NAME}.tar.xz"
 COMPRESSION_FLAGS="-cJvf"
 
-if [ "${RELEASE_NAME}" = "mainline" ]; then
-    DIR_NAME="${REV_NAME}"
+if [ "${RELEASE_NAME}" = "mainline" ] || [ "${RELEASE_NAME}" = "early-access" ]; then
+    DIR_NAME="${BASE_NAME}-${RELEASE_NAME}"
 else
-    DIR_NAME="${REV_NAME}_${RELEASE_NAME}"
+    DIR_NAME="${REV_NAME}-${RELEASE_NAME}"
 fi
 
 mkdir "$DIR_NAME"
 
 cp build/bin/yuzu-cmd "$DIR_NAME"
-cp build/bin/yuzu "$DIR_NAME"
+if [ "${RELEASE_NAME}" != "early-access" ] && [ "${RELEASE_NAME}" != "mainline" ]; then
+    cp build/bin/yuzu "$DIR_NAME"
+fi
 
 # Build an AppImage
 cd build
@@ -30,6 +33,11 @@ chmod 755 appimagetool-x86_64.AppImage
 # if FUSE is not available, then fallback to extract and run
 if ! ./appimagetool-x86_64.AppImage --version; then
     export APPIMAGE_EXTRACT_AND_RUN=1
+fi
+
+# Don't let AppImageLauncher ask to integrate EA
+if [ "${RELEASE_NAME}" = "mainline" ] || [ "${RELEASE_NAME}" = "early-access" ]; then
+    echo "X-AppImage-Integrate=false" >> AppDir/org.yuzu_emu.yuzu.desktop
 fi
 
 if [ "${RELEASE_NAME}" = "mainline" ]; then
@@ -44,6 +52,11 @@ cd ..
 cp "build/${APPIMAGE_NAME}" "${ARTIFACTS_DIR}/"
 if [ -f "build/${APPIMAGE_NAME}.zsync" ]; then
     cp "build/${APPIMAGE_NAME}.zsync" "${ARTIFACTS_DIR}/"
+fi
+
+# Copy the AppImage to the general release directory and remove git revision info
+if [ "${RELEASE_NAME}" = "mainline" ] || [ "${RELEASE_NAME}" = "early-access" ]; then
+    cp "build/${APPIMAGE_NAME}" "${DIR_NAME}/yuzu-${RELEASE_NAME}.AppImage"
 fi
 
 . .ci/scripts/common/post-upload.sh

--- a/.ci/yuzu-patreon-step2.yml
+++ b/.ci/yuzu-patreon-step2.yml
@@ -11,9 +11,30 @@ stages:
 - stage: build
   displayName: 'build'
   jobs:
-  - job: build
+  - job: linux
     timeoutInMinutes: 120
-    displayName: 'windows-msvc'
+    displayName: 'linux'
+    pool:
+      vmImage: ubuntu-latest
+    strategy:
+      maxParallel: 10
+      matrix:
+        linux:
+          BuildSuffix: 'linux'
+          ScriptFolder: 'linux'
+    steps:
+    - template: ./templates/sync-source.yml
+      parameters:
+        artifactSource: $(parameters.artifactSource)
+        needSubmodules: 'true'
+    - template: ./templates/build-single.yml
+      parameters:
+        artifactSource: 'false'
+        cache: $(parameters.cache)
+        version: $(DisplayVersion)
+  - job: msvc
+    timeoutInMinutes: 120
+    displayName: 'windows'
     pool:
       vmImage: windows-2019
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,11 @@ endif()
 configure_file(${PROJECT_SOURCE_DIR}/dist/compatibility_list/compatibility_list.qrc
                ${PROJECT_BINARY_DIR}/dist/compatibility_list/compatibility_list.qrc
                COPYONLY)
+if (EXISTS ${PROJECT_SOURCE_DIR}/dist/compatibility_list/compatibility_list.json)
+    configure_file("${PROJECT_SOURCE_DIR}/dist/compatibility_list/compatibility_list.json"
+                   "${PROJECT_BINARY_DIR}/dist/compatibility_list/compatibility_list.json"
+                   COPYONLY)
+endif()
 if (ENABLE_COMPATIBILITY_LIST_DOWNLOAD AND NOT EXISTS ${PROJECT_BINARY_DIR}/dist/compatibility_list/compatibility_list.json)
     message(STATUS "Downloading compatibility list for yuzu...")
     file(DOWNLOAD

--- a/src/core/arm/dynarmic/arm_dynarmic_32.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic_32.cpp
@@ -125,7 +125,9 @@ public:
     }
 
     void AddTicks(u64 ticks) override {
-        ASSERT_MSG(!parent.uses_wall_clock, "This should never happen - dynarmic ticking disabled");
+        if (parent.uses_wall_clock) {
+            return;
+        }
 
         // Divide the number of ticks by the amount of CPU cores. TODO(Subv): This yields only a
         // rough approximation of the amount of executed ticks in the system, it may be thrown off
@@ -142,7 +144,12 @@ public:
     }
 
     u64 GetTicksRemaining() override {
-        ASSERT_MSG(!parent.uses_wall_clock, "This should never happen - dynarmic ticking disabled");
+        if (parent.uses_wall_clock) {
+            if (!parent.interrupt_handlers[parent.core_index].IsInterrupted()) {
+                return minimum_run_cycles;
+            }
+            return 0U;
+        }
 
         return std::max<s64>(parent.system.CoreTiming().GetDowncount(), 0);
     }
@@ -172,7 +179,7 @@ public:
     Core::Memory::Memory& memory;
     std::size_t num_interpreted_instructions{};
     bool debugger_enabled{};
-    static constexpr u64 minimum_run_cycles = 1000U;
+    static constexpr u64 minimum_run_cycles = 10000U;
 };
 
 std::shared_ptr<Dynarmic::A32::Jit> ARM_Dynarmic_32::MakeJit(Common::PageTable* page_table) const {
@@ -200,7 +207,7 @@ std::shared_ptr<Dynarmic::A32::Jit> ARM_Dynarmic_32::MakeJit(Common::PageTable* 
 
     // Timing
     config.wall_clock_cntpct = uses_wall_clock;
-    config.enable_cycle_counting = !uses_wall_clock;
+    config.enable_cycle_counting = true;
 
     // Code cache size
     config.code_cache_size = 512_MiB;

--- a/src/core/arm/dynarmic/arm_dynarmic_64.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic_64.cpp
@@ -166,7 +166,9 @@ public:
     }
 
     void AddTicks(u64 ticks) override {
-        ASSERT_MSG(!parent.uses_wall_clock, "This should never happen - dynarmic ticking disabled");
+        if (parent.uses_wall_clock) {
+            return;
+        }
 
         // Divide the number of ticks by the amount of CPU cores. TODO(Subv): This yields only a
         // rough approximation of the amount of executed ticks in the system, it may be thrown off
@@ -181,7 +183,12 @@ public:
     }
 
     u64 GetTicksRemaining() override {
-        ASSERT_MSG(!parent.uses_wall_clock, "This should never happen - dynarmic ticking disabled");
+        if (parent.uses_wall_clock) {
+            if (!parent.interrupt_handlers[parent.core_index].IsInterrupted()) {
+                return minimum_run_cycles;
+            }
+            return 0U;
+        }
 
         return std::max<s64>(parent.system.CoreTiming().GetDowncount(), 0);
     }
@@ -216,7 +223,7 @@ public:
     u64 tpidrro_el0 = 0;
     u64 tpidr_el0 = 0;
     bool debugger_enabled{};
-    static constexpr u64 minimum_run_cycles = 1000U;
+    static constexpr u64 minimum_run_cycles = 10000U;
 };
 
 std::shared_ptr<Dynarmic::A64::Jit> ARM_Dynarmic_64::MakeJit(Common::PageTable* page_table,
@@ -260,7 +267,7 @@ std::shared_ptr<Dynarmic::A64::Jit> ARM_Dynarmic_64::MakeJit(Common::PageTable* 
 
     // Timing
     config.wall_clock_cntpct = uses_wall_clock;
-    config.enable_cycle_counting = !uses_wall_clock;
+    config.enable_cycle_counting = true;
 
     // Code cache size
     config.code_cache_size = 512_MiB;

--- a/src/video_core/macro/macro_hle.cpp
+++ b/src/video_core/macro/macro_hle.cpp
@@ -3,6 +3,8 @@
 
 #include <array>
 #include <vector>
+#include "common/scope_exit.h"
+#include "video_core/dirty_flags.h"
 #include "video_core/engines/maxwell_3d.h"
 #include "video_core/macro/macro.h"
 #include "video_core/macro/macro_hle.h"
@@ -58,6 +60,7 @@ void HLE_0217920100488FF7(Engines::Maxwell3D& maxwell3d, const std::vector<u32>&
     maxwell3d.regs.index_array.first = parameters[3];
     maxwell3d.regs.reg_array[0x446] = element_base; // vertex id base?
     maxwell3d.regs.index_array.count = parameters[1];
+    maxwell3d.dirty.flags[VideoCommon::Dirty::IndexBuffer] = true;
     maxwell3d.regs.vb_element_base = element_base;
     maxwell3d.regs.vb_base_instance = base_instance;
     maxwell3d.mme_draw.instance_count = instance_count;
@@ -80,10 +83,67 @@ void HLE_0217920100488FF7(Engines::Maxwell3D& maxwell3d, const std::vector<u32>&
     maxwell3d.mme_draw.current_mode = Engines::Maxwell3D::MMEDrawMode::Undefined;
 }
 
-constexpr std::array<std::pair<u64, HLEFunction>, 3> hle_funcs{{
+// Multidraw Indirect
+void HLE_3f5e74b9c9a50164(Engines::Maxwell3D& maxwell3d, const std::vector<u32>& parameters) {
+    SCOPE_EXIT({
+        // Clean everything.
+        maxwell3d.regs.reg_array[0x446] = 0x0; // vertex id base?
+        maxwell3d.regs.index_array.count = 0;
+        maxwell3d.regs.vb_element_base = 0x0;
+        maxwell3d.regs.vb_base_instance = 0x0;
+        maxwell3d.mme_draw.instance_count = 0;
+        maxwell3d.CallMethodFromMME(0x8e3, 0x640);
+        maxwell3d.CallMethodFromMME(0x8e4, 0x0);
+        maxwell3d.CallMethodFromMME(0x8e5, 0x0);
+        maxwell3d.mme_draw.current_mode = Engines::Maxwell3D::MMEDrawMode::Undefined;
+        maxwell3d.dirty.flags[VideoCommon::Dirty::IndexBuffer] = true;
+    });
+    const u32 start_indirect = parameters[0];
+    const u32 end_indirect = parameters[1];
+    if (start_indirect >= end_indirect) {
+        // Nothing to do.
+        return;
+    }
+    const auto topology =
+        static_cast<Tegra::Engines::Maxwell3D::Regs::PrimitiveTopology>(parameters[2]);
+    maxwell3d.regs.draw.topology.Assign(topology);
+    const u32 padding = parameters[3];
+    const std::size_t max_draws = parameters[4];
+
+    const u32 indirect_words = 5 + padding;
+    const std::size_t first_draw = start_indirect;
+    const std::size_t effective_draws = end_indirect - start_indirect;
+    const std::size_t last_draw = start_indirect + std::min(effective_draws, max_draws);
+
+    for (std::size_t index = first_draw; index < last_draw; index++) {
+        const std::size_t base = index * indirect_words + 5;
+        const u32 num_vertices = parameters[base];
+        const u32 instance_count = parameters[base + 1];
+        const u32 first_index = parameters[base + 2];
+        const u32 base_vertex = parameters[base + 3];
+        const u32 base_instance = parameters[base + 4];
+        maxwell3d.regs.index_array.first = first_index;
+        maxwell3d.regs.reg_array[0x446] = base_vertex;
+        maxwell3d.regs.index_array.count = num_vertices;
+        maxwell3d.regs.vb_element_base = base_vertex;
+        maxwell3d.regs.vb_base_instance = base_instance;
+        maxwell3d.mme_draw.instance_count = instance_count;
+        maxwell3d.CallMethodFromMME(0x8e3, 0x640);
+        maxwell3d.CallMethodFromMME(0x8e4, base_vertex);
+        maxwell3d.CallMethodFromMME(0x8e5, base_instance);
+        maxwell3d.dirty.flags[VideoCommon::Dirty::IndexBuffer] = true;
+        if (maxwell3d.ShouldExecute()) {
+            maxwell3d.Rasterizer().Draw(true, true);
+        }
+        maxwell3d.mme_draw.current_mode = Engines::Maxwell3D::MMEDrawMode::Undefined;
+    }
+}
+
+constexpr std::array<std::pair<u64, HLEFunction>, 4> hle_funcs{{
     {0x771BB18C62444DA0, &HLE_771BB18C62444DA0},
     {0x0D61FC9FAAC9FCAD, &HLE_0D61FC9FAAC9FCAD},
     {0x0217920100488FF7, &HLE_0217920100488FF7},
+    {0x3f5e74b9c9a50164, &HLE_3f5e74b9c9a50164},
 }};
 
 class HLEMacroImpl final : public CachedMacro {
@@ -99,6 +159,7 @@ private:
     Engines::Maxwell3D& maxwell3d;
     HLEFunction func;
 };
+
 } // Anonymous namespace
 
 HLEMacro::HLEMacro(Engines::Maxwell3D& maxwell3d_) : maxwell3d{maxwell3d_} {}


### PR DESCRIPTION
The Vulkan renderer does not support setting vsync.   It currently prefers mailbox (Triple buffering) mode if found. 

Mailbox mode avoids tearing, but it has a downside: it does not keep the emulation in sync with the real display.   If the emulation and display are very close to precise sync, there can be fits of juddering when the newly generated frames don't decisively fall as next in the display's sequence.  

Related to issue #7310.   I experienced the same behavior as [DelghLay](https://github.com/DelghLay).   Yuzu shows a rock solid 60fps, but the display judders for ~30 seconds or so every few minutes.   After switching the code to use FIFO mode, the issue goes away completely and scrolling games like Metroid Dread and Link's Awakening become butter smooth.   I'm using the existing vsync checkbox so I can still disable it for less performant titles. 

A better fix would be to give access to more vulkan swap mode options.  
